### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -33,5 +33,13 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
-      - name: Compile
-        run: csbt compile < /dev/null
+      - name: Compile and test
+        run: |
+          SBT_COMMANDS=$(cat << EOF
+          set core / Compile / scalacOptions += "-Werror";
+          set macros / Compile / scalacOptions += "-Werror";
+          compile;
+          test
+          EOF
+          )
+          csbt "${SBT_COMMANDS}" < /dev/null

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -35,11 +35,9 @@ jobs:
           java-version: adopt@1.11
       - name: Compile and test
         run: |
-          SBT_COMMANDS=$(cat << EOF
-          set core / Compile / scalacOptions += "-Werror";
-          set macros / Compile / scalacOptions += "-Werror";
-          compile;
-          test
-          EOF
-          )
-          csbt "${SBT_COMMANDS}" < /dev/null
+          csbt \
+            'set core / Compile / scalacOptions += "-Werror"' \
+            'set macros / Compile / scalacOptions += "-Werror"' \
+            compile \
+            test \
+            < /dev/null

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -32,13 +32,13 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
-      - name: Compile
+      - name: Compile and test
         run: |
           SBT_COMMANDS=$(cat << EOF
-          set core / Compile / scalacOptions += "-Werror"
-          set core / Compile / scalacOptions += "-Werror"
-          compile
-          Test / compile
+          set core / Compile / scalacOptions += "-Werror";
+          set macros / Compile / scalacOptions += "-Werror";
+          compile;
+          test
           EOF
           )
           csbt "${SBT_COMMANDS}" < /dev/null

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -34,11 +34,9 @@ jobs:
           java-version: adopt@1.11
       - name: Compile and test
         run: |
-          SBT_COMMANDS=$(cat << EOF
-          set core / Compile / scalacOptions += "-Werror";
-          set macros / Compile / scalacOptions += "-Werror";
-          compile;
-          test
-          EOF
-          )
-          csbt "${SBT_COMMANDS}" < /dev/null
+          csbt \
+            'set core / Compile / scalacOptions += "-Werror"' \
+            'set macros / Compile / scalacOptions += "-Werror"' \
+            compile \
+            test \
+            < /dev/null

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -33,4 +33,12 @@ jobs:
         with:
           java-version: adopt@1.11
       - name: Compile
-        run: csbt compile < /dev/null
+        run: |
+          SBT_COMMANDS=$(cat << EOF
+          set core / Compile / scalacOptions += "-Werror"
+          set core / Compile / scalacOptions += "-Werror"
+          compile
+          Test / compile
+          EOF
+          )
+          csbt "${SBT_COMMANDS}" < /dev/null

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala213               = "2.13.4"
+lazy val scala213               = "2.13.5"
 lazy val scala212               = "2.12.10"
 lazy val scala211               = "2.11.12"
 lazy val scala3                 = "3.0.0-M3"
@@ -50,7 +50,7 @@ val sharedSettings = Seq(
   Compile / scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, n)) if n <= 12 => List("-Ypartial-unification")
-      case _                       => List("-Ymacro-annotations", "-Ywarn-unused")
+      case _                       => List("-Ymacro-annotations", "-Ywarn-unused", "-Wmacros:after")
     }
   }
 )

--- a/core/src/test/scala/zio/magic/ProvideMagicLayerSpec.scala
+++ b/core/src/test/scala/zio/magic/ProvideMagicLayerSpec.scala
@@ -168,11 +168,6 @@ object ProvideMagicLayerSpec extends DefaultRunnableSpec {
   }
 
   private def compileErrorSuite = {
-    val program = for {
-      int    <- ZIO.service[Int]
-      string <- ZIO.service[String]
-    } yield string * int
-
     suite("compile errors")(
       testM("it reports missing layers") {
         val checked = typeCheck(" val provided = program.provideMagicLayer(ZLayer.succeed(3)) ")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt"   % "sbt-pgp"      % "2.1.2")
-addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix" % "0.9.25")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix" % "0.9.26")


### PR DESCRIPTION
- Upgrade to Scala 2.13.5 and add `-Wmacros:after` to `scalacOptions`
- Add `-Werror` in CI jobs so that all warnings are treated as hard errors to fail the jobs.
- Run sbt `test` as well in CI
- Remove an unused code block in test (`val program = ...`)

Note that this will currently fail the CI job, which is expected until this warning is fixed:

```
zio-magic/core/src/test/scala/zio/magic/SpecProvideMagicLayerSpec.scala:28:26: local val layer$macro$1 in method provideCustomMagicLayerShared is never used
[error]       .injectCustomShared(ZLayer.succeed(true), ZLayer.succeed("MAGIC!"))
```

Which is related to https://github.com/kitlangton/zio-magic/issues/46