### PR TITLE
Fix missing provideSomeLayerManualShared in ZSpecProvideSomeMagicLayerSharedPartiallyApplied

### DIFF
--- a/core/src/main/scala/zio/magic/package.scala
+++ b/core/src/main/scala/zio/magic/package.scala
@@ -171,5 +171,8 @@ package object magic {
       extends AnyVal {
     def apply[E1 >: E](layers: ZLayer[_, E1, _]*): Spec[In, E1, A] =
       macro SpecLayerMacros.injectSomeLayerSharedImpl[In, R, E1, A]
+
+    def provideSomeLayerManualShared[R0 <: Has[_]]: Spec.ProvideSomeLayerShared[R0, R, E, A] =
+      new Spec.ProvideSomeLayerShared[R0, R, E, A](spec)
   }
 }

--- a/core/src/test/scala/zio/magic/SpecProvideMagicLayerSpec.scala
+++ b/core/src/test/scala/zio/magic/SpecProvideMagicLayerSpec.scala
@@ -9,7 +9,8 @@ object SpecProvideMagicLayerSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("SpecProvideMagicLayerSpec")(
       provideCustomMagicLayerShared,
-      provideSomeMagicLayer
+      provideSomeMagicLayer,
+      provideSomeMagicLayerShared
     )
 
   private def provideCustomMagicLayerShared =
@@ -48,5 +49,20 @@ object SpecProvideMagicLayerSpec extends DefaultRunnableSpec {
       }
     )
       .injectSome[Has[In]](refLayer, strLayer)
+      .provideLayer(inLayer)
+
+  private def provideSomeMagicLayerShared =
+    (suite("provideSomeMagicLayerShared")(
+      testM("string") {
+        assertM(ZIO.service[String])(equalTo("str from layer"))
+      },
+      testM("shared ref") {
+        assertM(ZIO.service[Ref[Int]].flatMap(_.getAndUpdate(_ + 1)))(equalTo(0))
+      },
+      testM("new shared ref") {
+        assertM(ZIO.service[Ref[Int]].flatMap(_.getAndUpdate(_ + 1)))(equalTo(1))
+      }
+    ) @@ TestAspect.sequential)
+      .injectSomeShared[Has[In]](refLayer, strLayer)
       .provideLayer(inLayer)
 }


### PR DESCRIPTION
Spec#injectSomeShared currently does not compile with error:

```
value provideSomeLayerManualShared is not a member of zio.magic.package.ZSpecProvideSomeMagicLayerSharedPartiallyApplied
```

 This should fix it.