### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -30,14 +30,10 @@ jobs:
           path: ~/.jabba
           key: ${{ runner.os }}-jabba-${{ hashFiles('build.sbt') }}
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
       - name: Compile and test
         run: |
-          csbt \
+          sbt \
             'set core / Compile / scalacOptions += "-Werror"' \
             'set macros / Compile / scalacOptions += "-Werror"' \
             compile \
-            test \
-            < /dev/null
+            test

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Compile and test
         run: |
           sbt \
-            'set core / Compile / scalacOptions += "-Werror"' \
-            'set macros / Compile / scalacOptions += "-Werror"' \
+            'set core.jvm / Compile / scalacOptions += "-Werror"' \
+            'set core.js / Compile / scalacOptions += "-Werror"' \
+            'set macros.jvm / Compile / scalacOptions += "-Werror"' \
+            'set macros.js / Compile / scalacOptions += "-Werror"' \
             compile \
             test

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -29,14 +29,12 @@ jobs:
           path: ~/.jabba
           key: ${{ runner.os }}-jabba-${{ hashFiles('build.sbt') }}
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
       - name: Compile and test
         run: |
-          csbt \
-            'set core / Compile / scalacOptions += "-Werror"' \
-            'set macros / Compile / scalacOptions += "-Werror"' \
+          sbt \
+            'set core.jvm / Compile / scalacOptions += "-Werror"' \
+            'set core.js / Compile / scalacOptions += "-Werror"' \
+            'set macros.jvm / Compile / scalacOptions += "-Werror"' \
+            'set macros.js / Compile / scalacOptions += "-Werror"' \
             compile \
-            test \
-            < /dev/null
+            test


### PR DESCRIPTION
Looks like we ran into this issue since upgrading to `sbt 1.5.0`: https://github.com/olafurpg/setup-scala/issues/35

Since `sbt` launcher is baked into Github actions Ubuntu VM already, we can just use it instead.