### PR TITLE
Fix JDK 8 support by removing String.isBlank usage

### DIFF
--- a/macros/src/main/scala/zio/magic/macros/utils/ZLayerExprBuilder.scala
+++ b/macros/src/main/scala/zio/magic/macros/utils/ZLayerExprBuilder.scala
@@ -69,7 +69,7 @@ final case class ZLayerExprBuilder[Key, A](
   private def reportErrorMessage(errorMessage: String): Nothing = {
     val body = errorMessage.linesIterator
       .map { line =>
-        if (line.isBlank)
+        if (line.trim().isEmpty())
           line
         else
           "❯ ".red + line


### PR DESCRIPTION
fixes https://github.com/kitlangton/zio-magic/issues/67

Remove use of String.isBlank which is only present in JDK 11 and above. Theoretically the replacement of String.trim.isEmpty is slower, but the usage is only for compile failure error messages, so happy path performance wouldn't be affected.

Feedback welcome