### PR TITLE
Fix compiler warnings

### DIFF
--- a/macros/src/main/scala/zio/magic/macros/utils/ZLayerExprBuilder.scala
+++ b/macros/src/main/scala/zio/magic/macros/utils/ZLayerExprBuilder.scala
@@ -2,7 +2,6 @@ package zio.magic.macros.utils
 
 import zio.magic.macros.LayerCompose
 import zio.magic.macros.graph.{Graph, GraphError, Node}
-import zio.magic.macros.utils.StringSyntax.StringOps
 import zio.magic.macros.utils.ansi.AnsiStringOps
 import zio.{Chunk, NonEmptyChunk}
 


### PR DESCRIPTION
It seems that some earlier refactoring in 9ce01b1e868c7061784dcf9e1d8ddeb08d56d4c1 removing unused layers left some warnings and CI has been added that fails on warnings.

After that last PR  https://github.com/kitlangton/zio-magic/pull/68 was merged  I saw the build was broken, but the changes are unrelated, but its not nice to see broken builds :smile: 