### PR TITLE
Fixing compilation with ZIO 1.0.8

### DIFF
--- a/core/src/test/scala/zio/magic/AutoLayerSpec.scala
+++ b/core/src/test/scala/zio/magic/AutoLayerSpec.scala
@@ -128,7 +128,7 @@ object AutoLayerSpec extends DefaultRunnableSpec {
           testM("automatically constructs a layer from its dependencies, leaving off ZEnv") {
             trait Bank
             val program: ZIO[Console with Has[Bank], Nothing, Unit] =
-              ZIO.service[Bank] *> console.putStrLn("hi")
+              ZIO.service[Bank] *> console.putStrLn("hi").orDie
 
             val layer: ULayer[Has[Bank]] = ZLayer.succeed(new Bank {})
 

--- a/examples/src/main/scala/examples/ComplexExample.scala
+++ b/examples/src/main/scala/examples/ComplexExample.scala
@@ -32,7 +32,7 @@ object ComplexExample extends App {
       for {
         a <- ZIO.accessM[A](_.get.string)
         j <- ZIO.accessM[J](_.get.string)
-        _ <- console.putStrLn(s"Result:\n$a\n$j")
+        _ <- console.putStrLn(s"Result:\n$a\n$j").orDie
       } yield ()
 
     val satisfied: ZIO[Any, E, Unit] =

--- a/examples/src/main/scala/examples/Example.scala
+++ b/examples/src/main/scala/examples/Example.scala
@@ -55,7 +55,7 @@ private object Example extends App {
     val program: ZIO[Console with Cake, Nothing, Int] =
       for {
         isDelicious <- Cake.isDelicious
-        _           <- console.putStrLn(s"Pie is delicious: $isDelicious")
+        _           <- console.putStrLn(s"Pie is delicious: $isDelicious").orDie
       } yield 3
 
     // Tho old way... oh no!


### PR DESCRIPTION
Console APIs can now fail, so sprinkling `.orDie` to make it happy.

@kitlangton: it's still failing for 2 reasons: unused locals (in tests), and the `wireDebug` output.